### PR TITLE
Fix missing variable declaration in hxviewergrids.pas

### DIFF
--- a/source/hxviewergrids.pas
+++ b/source/hxviewergrids.pas
@@ -201,6 +201,7 @@ var
   dbl: Double;
   len: Integer;
   ws: WideString = '';
+  ext10: TExtended10; 
 begin
   if AItem = nil then
   begin


### PR DESCRIPTION
Missing declaration of ext10 causes compilation to fail on Lazarus 3.0RC2