### PR TITLE
Adding CI/CD with `setup-lazarus`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,47 @@
+name: LevelDB Object Pascal
+
+defaults:
+    run:
+        shell: bash
+
+
+permissions:
+    contents: write
+
+on:
+
+    push:
+        branches: [ main ]
+        tags: [ "*" ]
+        paths-ignore: [ "README.md", "LICENSE" ]
+
+    pull_request:
+        branches: [ main ]
+
+jobs:
+
+    build:
+        name: Build
+        runs-on: ${{ matrix.operating-system }}
+
+        strategy:
+            fail-fast: false
+            matrix:
+                operating-system: [ ubuntu-20.04, ubuntu-latest, windows-latest]
+                lazarus-versions: [ stable ]
+
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+              clean: true
+              set-safe-directory: true
+
+        - name: Install Lazarus
+          uses: gcarreno/setup-lazarus@v3
+          with:
+              lazarus-version: ${{ matrix.lazarus-versions }}
+              with-cache: false
+
+        - name: Build Application
+          run: lazbuild -B --bm=Release "source/Hex.lpi"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,12 +11,12 @@ permissions:
 on:
 
     push:
-        branches: [ main]
+        branches: [ master ]
         tags: [ "*" ]
         paths-ignore: [ "README.md", "LICENSE" ]
 
     pull_request:
-        branches: [ main ]
+        branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,3 +45,10 @@ jobs:
 
         - name: Build Application
           run: lazbuild -B --bm=Release "source/Hex.lpi"
+
+        - name: Upload Application
+          uses: actions/upload-artifact@v4
+          with:
+            name: Hex-${{ matrix.operating-system }}
+            path: bin/Hex*
+            

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,9 +73,13 @@ jobs:
         - name: Create archives
           run: |
             cd Hex-ubuntu-latest
-            tar zcvf ../Hex-ubuntu-x86_64-${{ github.ref_name }}.tgz Hex
+            mv Hex hex
+            chmod +x hex
+            tar zcvf ../Hex-ubuntu-x86_64-${{ github.ref_name }}.tgz hex
             cd ../Hex-ubuntu-20.04
-            tar zcvf ../Hex-ubuntu-20.04-x86_64-${{ github.ref_name }}.tgz Hex
+            mv Hex hex
+            chmod +x hex
+            tar zcvf ../Hex-ubuntu-20.04-x86_64-${{ github.ref_name }}.tgz hex
             cd ../Hex-windows-latest
             zip ../Hex-windows-x86_64-${{ github.ref_name }}.zip Hex.exe
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,12 +11,12 @@ permissions:
 on:
 
     push:
-        branches: [ main, gus-ci-cd ]
+        branches: [ main]
         tags: [ "*" ]
         paths-ignore: [ "README.md", "LICENSE" ]
 
     pull_request:
-        branches: [ main, gus-ci-cd ]
+        branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,7 @@ jobs:
 
         name: Release Application
         runs-on: ubuntu-latest
+        needs: build
 
         steps:
         - name: Checkout repository
@@ -68,6 +69,9 @@ jobs:
               
         - name: Download the Release binaries
           uses: actions/download-artifact@v4
+
+        - name: List files
+          run: ls -alF
       
         - name: Create archives
           run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,23 +70,14 @@ jobs:
         - name: Download the Release binaries
           uses: actions/download-artifact@v4
 
-        - name: List files
-          run: ls -alF
-      
         - name: Create archives
           run: |
-            if [ -d "Hex-ubuntu-latest" ]; then
-              cd Hex-ubuntu-latest
-              tar zcvf ../Hex-linux-x86_64-v${{ github.ref_name }}.tgz Hex
-            fi
-            if [ -d "Hex-ubuntu-20.04" ]; then
-              cd Hex-ubuntu-20.04
-              tar zcvf ../Hex-ubuntu-20.04-x86_64-v${{ github.ref_name }}.tgz Hex
-            fi
-            if [ -d "Hex-windows-latest" ]; then
-              cd Hex-windows-latest
-              zip ../Hex-windows-x86_64-v${{ github.ref_name }}.zip Hex.exe
-            fi
+            cd Hex-ubuntu-latest
+            tar zcvf ../Hex-ubuntu-x86_64-${{ github.ref_name }}.tgz Hex
+            cd ../Hex-ubuntu-20.04
+            tar zcvf ../Hex-ubuntu-20.04-x86_64-${{ github.ref_name }}.tgz Hex
+            cd ../Hex-windows-latest
+            zip ../Hex-windows-x86_64-${{ github.ref_name }}.zip Hex.exe
 
         - name: Create GitHub release
           uses: softprops/action-gh-release@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,12 +11,12 @@ permissions:
 on:
 
     push:
-        branches: [ main ]
+        branches: [ main, gus-ci-cd ]
         tags: [ "*" ]
         paths-ignore: [ "README.md", "LICENSE" ]
 
     pull_request:
-        branches: [ main ]
+        branches: [ main, gus-ci-cd ]
 
 jobs:
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,4 +51,47 @@ jobs:
           with:
             name: Hex-${{ matrix.operating-system }}
             path: bin/Hex*
-            
+    
+    release:
+        if: contains(github.ref_type, 'tag')
+
+        name: Release Application
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+              fetch-depth: 0
+              clean: true
+              set-safe-directory: true
+              
+        - name: Download the Release binaries
+          uses: actions/download-artifact@v4
+      
+        - name: Create archives
+          run: |
+            if [ -d "Hex-ubuntu-latest" ]; then
+              cd Hex-ubuntu-latest
+              tar zcvf ../Hex-linux-x86_64-v${{ github.ref_name }}.tgz Hex
+            fi
+            if [ -d "Hex-ubuntu-20.04" ]; then
+              cd Hex-ubuntu-20.04
+              tar zcvf ../Hex-ubuntu-20.04-x86_64-v${{ github.ref_name }}.tgz Hex
+            fi
+            if [ -d "Hex-windows-latest" ]; then
+              cd Hex-windows-latest
+              zip ../Hex-windows-x86_64-v${{ github.ref_name }}.zip Hex.exe
+            fi
+
+        - name: Create GitHub release
+          uses: softprops/action-gh-release@v1
+          with:
+              name: Hex ${{ github.ref_name }}
+              body: Needs to be changed
+              files: |
+                *.tgz
+                *.zip
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+## Project
+/bin
+
 # Uncomment these types if you want even more clean repository. But be careful.
 # It can make harm to an existing project source. Read explanations below.
 #
 # Resource files are binaries containing manifest, project icon and version info.
 # They can not be viewed as text or compared by diff-tools. Consider replacing them with .rc files.
-#*.res
+*.res
 #
 # Type library file (binary). In old Delphi versions it should be stored.
 # Since Delphi 2009 it is produced from .ridl file and can safely be ignored.
@@ -23,7 +26,7 @@
 # 
 # C++ object files produced when C/C++ Output file generation is configured.
 # Uncomment this if you are not using external objects (zlib library for example).
-#*.obj
+*.obj
 #
 
 # Delphi compiler-generated binaries (safe to delete)
@@ -58,9 +61,14 @@
 *.dsk
 
 # Delphi history and backups
+lib/
+backup/
 __history/
 __recovery/
 *.~*
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
+
+# Lazarus local files (user-specific info)
+*.lps

--- a/source/Hex.lpi
+++ b/source/Hex.lpi
@@ -30,12 +30,12 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="../bin/$(TargetCPU)-$(TargetOS)/Hex"/>
+            <Filename Value="..\bin\Hex"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="thirdparty"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
             <SyntaxOptions>
@@ -68,12 +68,12 @@
           <Version Value="11"/>
           <PathDelim Value="\"/>
           <Target>
-            <Filename Value="../bin/$(TargetCPU)-$(TargetOS)/Hex"/>
+            <Filename Value="..\bin\Hex"/>
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value="thirdparty"/>
-            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+            <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
@@ -278,12 +278,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="../bin/$(TargetCPU)-$(TargetOS)/Hex"/>
+      <Filename Value="..\bin\Hex"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="thirdparty"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Linking>
       <Debugging>

--- a/source/hxmain.lfm
+++ b/source/hxmain.lfm
@@ -9,7 +9,6 @@ object MainForm: TMainForm
   ClientWidth = 914
   Menu = MainMenu
   ShowHint = True
-  LCLVersion = '3.99.0.0'
   OnActivate = FormActivate
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
@@ -17,7 +16,7 @@ object MainForm: TMainForm
   OnShow = FormShow
   object PageControl: TPageControl
     Left = 0
-    Height = 432
+    Height = 435
     Top = 30
     Width = 914
     Align = alClient
@@ -157,8 +156,8 @@ object MainForm: TMainForm
   end
   object StatusBar: TStatusBar
     Left = 0
-    Height = 23
-    Top = 462
+    Height = 20
+    Top = 465
     Width = 914
     AutoHint = True
     Panels = <    
@@ -193,7 +192,6 @@ object MainForm: TMainForm
       Caption = 'Quit'
       Hint = 'Quit|Close application'
       ImageIndex = 1
-      ShortCut = 32856
       OnExecute = acFileQuitExecute
     end
     object acShowStatusbar: TAction

--- a/source/hxmain.pas
+++ b/source/hxmain.pas
@@ -255,6 +255,8 @@ type
     procedure UpdateCurrentHexEditor;
     procedure UpdateIconSet;
 
+    procedure InitShortcuts;
+
     procedure ReadIni;
     procedure WriteIni;
 
@@ -274,7 +276,7 @@ uses
   IniFiles, Math,
   MPHexEditor,
   hxStrings, hxUtils, {%H-}hxDataModule, hxObjectViewerFrame,
-  hxSettingsDlg, hxGotoDlg, hxAbout;
+  hxSettingsDlg, hxGotoDlg, hxAbout,LCLType;
 
 const
   PROG_NAME = 'Hex';
@@ -933,6 +935,8 @@ begin
   FRecentFilesManager.IniFileName := GetIniFileName;
   FRecentFilesManager.IniSection := 'RecentFiles';
 
+  InitShortcuts;
+
   AppendToObjectsMenu(mnuObjects);
   {
   ReadIni;
@@ -941,7 +945,7 @@ begin
 end;
 
 procedure TMainForm.FormDropFiles(Sender: TObject;
-  const FileNames: Array of String);
+  const FileNames: array of String);
 var
   fn: String;
 begin
@@ -1180,6 +1184,16 @@ begin
     F := GetHexEditorFrame(i);
     F.UpdateIconSet;
   end;
+end;
+
+procedure TMainForm.InitShortcuts;
+begin
+{$IFDEF UNIX}
+  acFileQuit.ShortCut := KeyToShortCut(VK_Q, [ssCtrl]);
+{$ENDIF}
+{$IFDEF WINDOWS}
+  acFileQuit.ShortCut := KeyToShortCut(VK_X, [ssAlt]);
+{$ENDIF}
 end;
 
 procedure TMainForm.WriteIni;

--- a/tests/hex_tests.lpi
+++ b/tests/hex_tests.lpi
@@ -12,8 +12,81 @@
       <ResourceType Value="res"/>
       <UseXPManifest Value="True"/>
     </General>
-    <BuildModes Count="1">
+    <BuildModes Count="3">
       <Item1 Name="Default" Default="True"/>
+      <Item2 Name="Debug">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\bin\hex_tests"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\source;..\source\thirdparty"/>
+            <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Parsing>
+            <SyntaxOptions>
+              <IncludeAssertionCode Value="True"/>
+            </SyntaxOptions>
+          </Parsing>
+          <CodeGeneration>
+            <Checks>
+              <IOChecks Value="True"/>
+              <RangeChecks Value="True"/>
+              <OverflowChecks Value="True"/>
+              <StackChecks Value="True"/>
+            </Checks>
+            <VerifyObjMethodCallValidity Value="True"/>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <DebugInfoType Value="dsDwarf3"/>
+              <UseHeaptrc Value="True"/>
+              <TrashVariables Value="True"/>
+              <UseExternalDbgSyms Value="True"/>
+            </Debugging>
+            <Options>
+              <Win32>
+                <GraphicApplication Value="True"/>
+              </Win32>
+            </Options>
+          </Linking>
+        </CompilerOptions>
+      </Item2>
+      <Item3 Name="Release">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\bin\hex_tests"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\source;..\source\thirdparty"/>
+            <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <CodeGeneration>
+            <SmartLinkUnit Value="True"/>
+            <Optimizations>
+              <OptimizationLevel Value="3"/>
+            </Optimizations>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <GenerateDebugInfo Value="False"/>
+              <RunWithoutDebug Value="True"/>
+            </Debugging>
+            <LinkSmart Value="True"/>
+            <Options>
+              <Win32>
+                <GraphicApplication Value="True"/>
+              </Win32>
+            </Options>
+          </Linking>
+        </CompilerOptions>
+      </Item3>
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
@@ -64,12 +137,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="hex_tests"/>
+      <Filename Value="..\bin\hex_tests"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\source;..\source\thirdparty"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\bin\lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Linking>
       <Debugging>


### PR DESCRIPTION
Hey @wp-xyz,

As requested by @theavege I'm submitting the CI/CD.

I've also made some changes to the paths in order to make it easier for the CI/CD actions to locate the binaries.

I've added a procedure called `InitShortcuts` that will use `Alt+X` for Windows and `Ctrl-Q` for Linux.

Did not add CI/CD for `macos-latest`. If you want it, just ask and I'll add it.

In order to trigger a new release, you just need to push a tag to GitHub.
Here are some examples from my testing: https://github.com/gcarreno/Hex/releases
There is a way to automate the release text. One ( of many ) that I use depends on another action that generates Markdown from the commit history. It kinda needs one to use the commit messages with a grouping. If you wanna learn more, hit me on the forums, please.

Alas, I was not able to quickly add a `CLI` version of the tests. Had some linking issues when I added `LCL` to the dependencies. Maybe you can sort that out and then add a `CLI` version of the tests that can be run by the GitHub actions.

Please give it a good look and then alter ( or ask for changes ) what you see fit.

Cheers,
Gus