### PR TITLE
Updated `CI`/`CD`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
               set-safe-directory: true
 
         - name: Install Lazarus
-          uses: gcarreno/setup-lazarus@v3.3.0
+          uses: gcarreno/setup-lazarus@v3
           with:
               lazarus-version: ${{ matrix.lazarus-versions }}
               with-cache: false
@@ -60,14 +60,7 @@ jobs:
           run: bin/hex_tests_cli --all --format=plain
 
         - name: Build Application
-          run: |
-            lazbuild -B --bm=Release "source/Hex.lpi"
-            if [ "${{ matrix.operating-system }}" == "ubuntu-lates" ] ; then
-              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
-              sudo apt install -y libqt5pas-dev
-              lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
-              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt5
-            fi
+          run: lazbuild -B --bm=Release "source/Hex.lpi"
 
         - name: Upload Application
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,7 @@ jobs:
           run: |
             lazbuild -B --bm=Release "source/Hex.lpi"
             if [ "${{ matrix.operating-system }}" == "windows-latest" ] ; then
-              lazbuild -B --bm=Release --cpu=i386 --os=win32 "sources/Hex.lpi"
+              lazbuild -B --bm=Release --cpu=i386 --os=win32 "source/Hex.lpi"
             fi
 
         - name: Upload Application

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,12 +64,9 @@ jobs:
             lazbuild -B --bm=Release "source/Hex.lpi"
             if [ "${{ matrix.operating-system }}" == "ubuntu-latest" ] ; then
               mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
-              sudo apt install -y libqt5pas
+              sudo apt install -y libqt5pas-dev
               lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
               mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt5
-              sudo apt install -y libqt6pas
-              lazbuild -B --bm=Release --ws=qt6 "source/Hex.lpi"
-              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt6
             fi
 
         - name: Upload Application

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,11 @@ jobs:
           run: bin/hex_tests_cli --all --format=plain
 
         - name: Build Application
-          run: lazbuild -B --bm=Release "source/Hex.lpi"
+          run: |
+            lazbuild -B --bm=Release "source/Hex.lpi"
+            if [ "${{ matrix.operating-system }}" == "windows-latest" ] ; then
+              lazbuild -B --bm=Release --cpu=i386 --os=win32 "sources/Hex.lpi"
+            fi
 
         - name: Upload Application
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,12 +27,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                operating-system: [ ubuntu-20.04, ubuntu-latest, windows-latest]
+                operating-system: [ ubuntu-latest, windows-latest]
                 lazarus-versions: [ stable ]
                 include:
-                    - operating-system: ubuntu-20.04
-                      folder: x86_64-linux
-                      binary: Hex
                     - operating-system: ubuntu-latest
                       folder: x86_64-linux
                       binary: Hex
@@ -92,10 +89,6 @@ jobs:
             mv Hex hex
             chmod +x hex
             tar zcvf ../Hex-ubuntu-x86_64-${{ github.ref_name }}.tgz hex
-            cd ../Hex-ubuntu-20.04
-            mv Hex hex
-            chmod +x hex
-            tar zcvf ../Hex-ubuntu-20.04-x86_64-${{ github.ref_name }}.tgz hex
             cd ../Hex-windows-latest
             zip ../Hex-windows-x86_64-${{ github.ref_name }}.zip Hex.exe
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,8 +62,8 @@ jobs:
         - name: Build Application
           run: |
             lazbuild -B --bm=Release "source/Hex.lpi"
-            if [ "${{ matrix.operating-system }}" == "windows-latest" ] ; then
-              lazbuild -B --bm=Release --cpu=i386 --os=win32 "source/Hex.lpi"
+            if [ "${{ matrix.operating-system }}" == "ubuntu-latest" ] ; then
+              lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
             fi
 
         - name: Upload Application

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,14 +60,7 @@ jobs:
           run: bin/hex_tests_cli --all --format=plain
 
         - name: Build Application
-          run: |
-            lazbuild -B --bm=Release "source/Hex.lpi"
-            if [ "${{ matrix.operating-system }}" == "ubuntu-20.04" ] ; then
-              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
-              sudo apt install -y libqt5pas-dev
-              lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
-              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt5
-            fi
+          run: lazbuild -B --bm=Release "source/Hex.lpi"
 
         - name: Upload Application
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
         - name: Build Application
           run: |
             lazbuild -B --bm=Release "source/Hex.lpi"
-            if [ "${{ matrix.operating-system }}" == "ubuntu-latest" ] ; then
+            if [ "${{ matrix.operating-system }}" == "ubuntu-20.04" ] ; then
               mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
               sudo apt install -y libqt5pas-dev
               lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
               set-safe-directory: true
 
         - name: Install Lazarus
-          uses: gcarreno/setup-lazarus@v3
+          uses: gcarreno/setup-lazarus@v3.3.0
           with:
               lazarus-version: ${{ matrix.lazarus-versions }}
               with-cache: false
@@ -60,7 +60,14 @@ jobs:
           run: bin/hex_tests_cli --all --format=plain
 
         - name: Build Application
-          run: lazbuild -B --bm=Release "source/Hex.lpi"
+          run: |
+            lazbuild -B --bm=Release "source/Hex.lpi"
+            if [ "${{ matrix.operating-system }}" == "ubuntu-lates" ] ; then
+              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
+              sudo apt install -y libqt5pas-dev
+              lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
+              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt5
+            fi
 
         - name: Upload Application
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ permissions:
 on:
 
     push:
-        branches: [ master, update-ci-cd ]
+        branches: [ master ]
         tags: [ "*" ]
         paths-ignore: [ "README.md", "LICENSE" ]
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ permissions:
 on:
 
     push:
-        branches: [ master ]
+        branches: [ master, update-ci-cd ]
         tags: [ "*" ]
         paths-ignore: [ "README.md", "LICENSE" ]
 
@@ -52,6 +52,12 @@ jobs:
           with:
               lazarus-version: ${{ matrix.lazarus-versions }}
               with-cache: false
+
+        - name: Build Test Application
+          run: lazbuild -B --bm=Release "tests/hex_tests_cli.lpi"
+
+        - name: Run Test Application
+          run: bin/hex_tests_cli --all --format=plain
 
         - name: Build Application
           run: lazbuild -B --bm=Release "source/Hex.lpi"
@@ -94,10 +100,10 @@ jobs:
             zip ../Hex-windows-x86_64-${{ github.ref_name }}.zip Hex.exe
 
         - name: Create GitHub release
-          uses: softprops/action-gh-release@v1
+          uses: softprops/action-gh-release@v2
           with:
               name: Hex ${{ github.ref_name }}
-              body: Needs to be changed
+              body_path: release_notes.md
               files: |
                 *.tgz
                 *.zip

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,13 @@ jobs:
           run: |
             lazbuild -B --bm=Release "source/Hex.lpi"
             if [ "${{ matrix.operating-system }}" == "ubuntu-latest" ] ; then
+              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-gtk2
+              sudo apt install -y libqt5pas
               lazbuild -B --bm=Release --ws=qt5 "source/Hex.lpi"
+              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt5
+              sudo apt install -y libqt6pas
+              lazbuild -B --bm=Release --ws=qt6 "source/Hex.lpi"
+              mv bin/${{ matrix.folder }}/${{ matrix.binary }} bin/${{ matrix.folder }}/${{ matrix.binary }}-qt6
             fi
 
         - name: Upload Application

--- a/tests/hex_tests_cli.lpi
+++ b/tests/hex_tests_cli.lpi
@@ -16,6 +16,69 @@
     </General>
     <BuildModes>
       <Item Name="Default" Default="True"/>
+      <Item Name="Debug">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\bin\hex_tests_cli"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\source\units"/>
+            <UnitOutputDirectory Value="..\ppu\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Parsing>
+            <SyntaxOptions>
+              <IncludeAssertionCode Value="True"/>
+            </SyntaxOptions>
+          </Parsing>
+          <CodeGeneration>
+            <Checks>
+              <IOChecks Value="True"/>
+              <RangeChecks Value="True"/>
+              <OverflowChecks Value="True"/>
+              <StackChecks Value="True"/>
+            </Checks>
+            <VerifyObjMethodCallValidity Value="True"/>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <DebugInfoType Value="dsDwarf3"/>
+              <UseHeaptrc Value="True"/>
+              <TrashVariables Value="True"/>
+              <UseExternalDbgSyms Value="True"/>
+            </Debugging>
+          </Linking>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Release">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="..\bin\hex_tests_cli"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <OtherUnitFiles Value="..\source\units"/>
+            <UnitOutputDirectory Value="..\ppu\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <CodeGeneration>
+            <SmartLinkUnit Value="True"/>
+            <Optimizations>
+              <OptimizationLevel Value="3"/>
+            </Optimizations>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <GenerateDebugInfo Value="False"/>
+              <RunWithoutDebug Value="True"/>
+            </Debugging>
+            <LinkSmart Value="True"/>
+          </Linking>
+        </CompilerOptions>
+      </Item>
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
@@ -48,12 +111,12 @@
     <Version Value="11"/>
     <PathDelim Value="\"/>
     <Target>
-      <Filename Value="hex_tests_cli"/>
+      <Filename Value="..\bin\hex_tests_cli"/>
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
       <OtherUnitFiles Value="..\source\units"/>
-      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+      <UnitOutputDirectory Value="..\ppu\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Linking>
       <Debugging>


### PR DESCRIPTION
Hey WP(@wp-xyz),

From the requests you made I was only able to add the `release_notes.md` change.

For `Win32`, the 64b install of Lazarus does not have the `i386` cross compiler, so that's a bust. It is possible, if I alter `setup-lazarus` some, but it would be a bit too much work for a dying platform, at least in my humble opinion.

For `Qt5`, there's a problem with Lazarus 3.0( the latest `setup-lazarus` is able to install ) and the version of `libqt5pas`. I think this has been resolved in newer versions. The fact of the matter is that the rewrite of `setup-lazarus` is now a bit involved and I need to see what's happening with that.

For `Qt6`, there's the issue that `libqt6pas-dev` is not on the repositories for Ubuntu 24.04 LTS, which I think is the version for `ubuntu-latest`. There may be a way around this, but I'll need to investigate how I should go about it.

I'm really sorry I couldn't implement all your suggestions. I'll revisit this once I have `setup-lazarus` all fixed up again.

You also had a question about `ubuntu-20.04`. I tend to use this because of issues with `GLIBC`. There are still people in the Linux universe that have some really old `GLIBC` version. And if I see the code can compile under it, I tend to include it. Alas, because I was able to fix `setup-lazarus`, and now it's using Lazarus 3.6 as `stable`, we no longer can use `ubuntu-20.04` as an option. So I had to remove it.

Are you interested in releasing for `macOS`? If so, gimme a shout so I can add that.

Cheers,
Gus